### PR TITLE
Use metadata-filter from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "express": "^4.17.1",
     "lodash": "^4.17.19",
     "luxon": "^1.24.1",
-    "metadata-filter": "github:web-scrobbler/metadata-filter#master",
+    "metadata-filter": "^1.0.0",
     "patch-package": "^6.2.2",
     "pg": "^8.3.0",
     "sqlite3": "^4.1.1",


### PR DESCRIPTION
I released `metadata-filter` v1.0.0 recently, so now it's safer to use install it from npm. :)